### PR TITLE
Add page w/ questionnaire, link it from homepage

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -8,7 +8,10 @@ home:
     <p>Tech Workers Coalition Netherlands is where tech workers come together to build collective power at work—whether you work as a customer service agent, software developer, delivery rider, warehouse worker, content moderator, copywriter, engineer, video game artist, service and kitchen staff, system administrator, UI/UX designer, or in an other tech-related role.</p>
     <p>What can tech workers achieve together? By organizing strategically, we can stick up for ourselves and support one another, for example to get higher wages, reduced work hours, protection of labour rights, healthier working conditions, dignity at work, and to fight against racism and discrimination. As tech workers, we can make technology that actually serves people, not just profit.</p> 
     <p>Your voice matters.</p>
-    <p>Currently Tech Workers Coalition Netherlands is in the process of starting up and gathering issues. What would you like to change about your work? Let’s join forces! <a href="https://techwerkers.nl/join">Sign up to receive updates and get involved.</a></p>
+    <p>Currently Tech Workers Coalition Netherlands is in the process of starting up and gathering issues. Let’s join forces! <a href="#hl-links">Sign up to receive updates and get involved.</a></p>
+    <form action="https://techwerkers.nl/change">
+      <input type="submit" value="What would you like to change about your work?" />
+    </form>
     <p>Tech won't save us: organize! 🤗</p>
   events:
     title: Recent and upcoming events

--- a/_i18n/nl.yml
+++ b/_i18n/nl.yml
@@ -8,7 +8,10 @@ home:
     <p>Techwerkerscoalitie Nederland is waar techwerkers samenkomen om onze krachten te bundelen—of je nu werkt als klantenservicemedewerker, software-ontwikkelaar, bezorger, magazijnmedewerker, inhoudsmoderator, tekstschrijver, ingenieur, video game-ontwikkelaar, systeembeheerder, UI/UX designer, in de keuken en bediening, of in wat voor tech-gerelateerde rol dan ook.</p>
     <p>Wat kunnen techwerkers samen bereiken? Door strategisch te organiseren, kunnen we voor onszelf opkomen en elkaar ondersteunen, bijvoorbeeld in het verkrijgen van een hoger loon, kortere werktijden, bescherming van onze arbeidsrechten, een gezondere werkomgeving, respect op de werkvloer, en om racisme en discriminatie te bestrijden. Als techwerkers kunnen we technologie maken die in dienst staat van mensen, en niet alleen van winst.</p>
     <p>Jouw stem telt.</p>
-    <p>Op dit moment is de Techwerkerscoalitie Nederland bezig met opstarten en actiepunten verzamelen. Wat zou jij graag anders hebben op je werk? Laten we de krachten bundelen! <a href="https://techwerkers.nl/join">Schrijf je in om op de hoogte te worden gehouden van ontwikkelingen en om mee te doen.</a></p>
+    <p>Op dit moment is de Techwerkerscoalitie Nederland bezig met opstarten en actiepunten verzamelen. Laten we de krachten bundelen! <a href="#hl-links">Schrijf je in om op de hoogte te worden gehouden van ontwikkelingen en om mee te doen.</a></p>
+    <form action="https://techwerkers.nl/change">
+      <input type="submit" value="Wat zou jij graag veranderen aan je werk?"/>
+    </form>
     <p>Tech gaat ons niet redden: organiseer! 🤗</p>
   events:
     title: Agenda

--- a/change.md
+++ b/change.md
@@ -1,0 +1,8 @@
+---
+layout: translated
+permalink: /change
+namespace: change
+languages: ["en"]
+---
+
+<iframe class="airtable-embed" src="https://airtable.com/embed/appB24weqWrkQbJCk/pagvRNEOFavr6R5wJ/form" frameborder="0" onmousewheel="" width="100%" height="1557" style="background: transparent; border: 1px solid #ccc;"></iframe>


### PR DESCRIPTION
This change:
- Adds a page with an Airtable questionnaire asking about 3 things ppl would like to change about their work. It's in EN only for now bc haven't had the time to set up bilingual options here.
- Links to this questionnaire page from the homepages (EN/NL) with a difficult-to-miss button