### PR TITLE
Remove temporary issue-gathering button EN, NL

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -11,11 +11,6 @@ home:
   summary: |
     <p>Tech Workers Coalition Netherlands is where tech workers come together to build collective power at work—whether you work as a customer service agent, software developer, delivery rider, warehouse worker, content moderator, copywriter, engineer, video game artist, service and kitchen staff, system administrator, UI/UX designer, or in an other tech-related role.</p>
     <p>What can tech workers achieve together? By organizing strategically, we can stick up for ourselves and support one another, for example to get higher wages, reduced work hours, protection of labour rights, healthier working conditions, dignity at work, and to fight against racism and discrimination. As tech workers, we can make technology that actually serves people, not just profit.</p> 
-    <h3>Your voice matters.</h3>
-    <p>Tech Workers Coalition Netherlands is currently starting up and gathering issues. Let’s join forces! What changes do you want to see in your work?</p>
-    <form action="https://techwerkers.nl/change">
-      <input type="submit" value="Share your thoughts with us" />
-    </form>
     <p>Tech won't save us: organize! 🤗</p>
     <a href="#hl-links">Sign up to receive updates and get involved.</a>
   events:

--- a/_i18n/nl.yml
+++ b/_i18n/nl.yml
@@ -11,13 +11,8 @@ home:
   summary: |
     <p>Techwerkerscoalitie Nederland is waar techwerkers samenkomen om onze krachten te bundelen—of je nu werkt als klantenservicemedewerker, software-ontwikkelaar, bezorger, magazijnmedewerker, inhoudsmoderator, tekstschrijver, ingenieur, video game-ontwikkelaar, systeembeheerder, UI/UX designer, in de keuken en bediening, of in wat voor tech-gerelateerde rol dan ook.</p>
     <p>Wat kunnen techwerkers samen bereiken? Door strategisch te organiseren, kunnen we voor onszelf opkomen en elkaar ondersteunen, bijvoorbeeld in het verkrijgen van een hoger loon, kortere werktijden, bescherming van onze arbeidsrechten, een gezondere werkomgeving, respect op de werkvloer, en om racisme en discriminatie te bestrijden. Als techwerkers kunnen we technologie maken die in dienst staat van mensen, en niet alleen van winst.</p>
-    <p>Jouw stem telt.</p>
-    <p>Op dit moment is de Techwerkerscoalitie Nederland bezig met opstarten en actiepunten verzamelen. Laten we de krachten bundelen! Wat zou jij graag veranderen aan je werk?</p>
-    <form action="https://techwerkers.nl/change">
-      <input type="submit" value="Deel uw mening met ons"/>
-    </form>
-    <p>Tech gaat ons niet redden: organiseer! 🤗<br/>
-    <a href="#hl-links">Schrijf je in om op de hoogte te worden gehouden van ontwikkelingen en om mee te doen.</a></p>
+    <p>Tech gaat ons niet redden: organiseer je! 🤗</p>
+    <a href="#hl-links">Schrijf je in om op de hoogte te worden gehouden van ontwikkelingen en om mee te doen.</a>
   events:
     title: Agenda
     more: Alle activiteiten


### PR DESCRIPTION
This change removes the temporary button for gathering work issues from the homepage in both the EN and NL versions. This button had been added for the MozFest event in early June. As this event has now passed, we can remove this button again -- as discussed in this [Slack conversation](https://techworkersco.slack.com/archives/C06NYM3271D/p1719557456287469?thread_ts=1719305663.184519&cid=C06NYM3271D).

Btw it was also pointed out that the blurb generally could be better, which is totally valid! This is just to make this specific, limited fix.