### PR TITLE
feat: introduce newsletter opt in to form

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -35,7 +35,7 @@ connect:
   company: Your employer
   number: Phone number
   how_did_hear: How can we support your personal goals?
-  receive_updates: Do you want to receive occasional email updates?
+  receive_updates: Sign up to receive occasional updates
   subscribe: Join
 
 global:

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -35,7 +35,7 @@ connect:
   company: Your employer
   number: Phone number
   how_did_hear: How can we support your personal goals?
-  receive_updates: Receive occasional email updates?
+  receive_updates: Do you want to receive occasional email updates?
   subscribe: Join
 
 global:

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -12,7 +12,6 @@ home:
     <p>Tech Workers Coalition Netherlands is where tech workers come together to build collective power at work—whether you work as a customer service agent, software developer, delivery rider, warehouse worker, content moderator, copywriter, engineer, video game artist, service and kitchen staff, system administrator, UI/UX designer, or in an other tech-related role.</p>
     <p>What can tech workers achieve together? By organizing strategically, we can stick up for ourselves and support one another, for example to get higher wages, reduced work hours, protection of labour rights, healthier working conditions, dignity at work, and to fight against racism and discrimination. As tech workers, we can make technology that actually serves people, not just profit.</p> 
     <p>Tech won't save us: organize! 🤗</p>
-    <a href="#hl-links">Sign up to receive updates and get involved.</a>
   events:
     title: Recent and upcoming events
     more: Find more events
@@ -36,6 +35,7 @@ connect:
   company: Your employer
   number: Phone number
   how_did_hear: How can we support your personal goals?
+  receive_updates: Receive occasional email updates?
   subscribe: Join
 
 global:

--- a/_i18n/nl.yml
+++ b/_i18n/nl.yml
@@ -12,7 +12,6 @@ home:
     <p>Techwerkerscoalitie Nederland is waar techwerkers samenkomen om onze krachten te bundelen—of je nu werkt als klantenservicemedewerker, software-ontwikkelaar, bezorger, magazijnmedewerker, inhoudsmoderator, tekstschrijver, ingenieur, video game-ontwikkelaar, systeembeheerder, UI/UX designer, in de keuken en bediening, of in wat voor tech-gerelateerde rol dan ook.</p>
     <p>Wat kunnen techwerkers samen bereiken? Door strategisch te organiseren, kunnen we voor onszelf opkomen en elkaar ondersteunen, bijvoorbeeld in het verkrijgen van een hoger loon, kortere werktijden, bescherming van onze arbeidsrechten, een gezondere werkomgeving, respect op de werkvloer, en om racisme en discriminatie te bestrijden. Als techwerkers kunnen we technologie maken die in dienst staat van mensen, en niet alleen van winst.</p>
     <p>Tech gaat ons niet redden: organiseer je! 🤗</p>
-    <a href="#hl-links">Schrijf je in om op de hoogte te worden gehouden van ontwikkelingen en om mee te doen.</a>
   events:
     title: Agenda
     more: Alle activiteiten

--- a/_i18n/nl.yml
+++ b/_i18n/nl.yml
@@ -33,6 +33,7 @@ connect:
   public_link_placeholder: LinkedIn, Xitter, Mastodon, etc.
   company: Werkgever
   how_did_hear: Wat zou jou helpen je doelen te bereiken? 
+  receive_updates: Wilt u af en toe e-mailupdates ontvangen?
   subscribe: Doe mee
 
 global:

--- a/_i18n/nl.yml
+++ b/_i18n/nl.yml
@@ -33,7 +33,7 @@ connect:
   public_link_placeholder: LinkedIn, Xitter, Mastodon, etc.
   company: Werkgever
   how_did_hear: Wat zou jou helpen je doelen te bereiken? 
-  receive_updates: Wilt u af en toe e-mailupdates ontvangen?
+  receive_updates: Meld u aan om af en toe updates te ontvangen
   subscribe: Doe mee
 
 global:

--- a/_includes/form-join.html
+++ b/_includes/form-join.html
@@ -55,6 +55,12 @@
         />
       </div>
 
+      <div>
+        <div class="control">
+          <label for="receive_updates">{% t connect.receive_updates %}</label>
+          <input id="receive_updates" name="receive_updates" type="checkbox"/>
+        </div>
+      </div>
 
       <button class="subscribe-button" type="submit">
         {% t connect.subscribe %}

--- a/_includes/form-join.html
+++ b/_includes/form-join.html
@@ -56,7 +56,7 @@
       </div>
 
       <div>
-        <div class="control">
+        <div class="control-checkbox">
           <label for="receive_updates">{% t connect.receive_updates %}</label>
           <input id="receive_updates" name="receive_updates" type="checkbox"/>
         </div>

--- a/_includes/main.scss
+++ b/_includes/main.scss
@@ -147,6 +147,19 @@ ul {
   }
 }
 
+.control-checkbox {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-top: 5px;
+  margin-bottom: 5px;
+  text-align: center;
+
+  input {
+    margin-left: .5em;
+  }
+}
+
 img {
   object-fit: cover;
   max-width: 100%;

--- a/_includes/main.scss
+++ b/_includes/main.scss
@@ -143,7 +143,7 @@ ul {
     display: block;
     margin-right: auto;
     margin-left: auto;
-    padding: 1%
+    padding: 1%;
   }
 }
 

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -35,6 +35,6 @@ layout: default
   <div class="post-content">
     {{ content }}
     <h2>{% translate connect.info %}</h2>
-    {% include links.html %}
+    {% include form-join.html %}
   </div>
 </article>

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -16,6 +16,6 @@ layout: default
     <h2>{% translate global.code_of_conduct.title %}</h2>
     {% translate global.code_of_conduct.summary %}
       <h2>{% translate connect.info %}</h2>
-      {% include links.html %}
+      {% include form-join.html %}
   </div>
 </article>

--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@ permalink: /
 
 <section class="titled-block" aria-labelledby="hl-links">
   <h2 id="hl-links">{% t connect.info %}</h2>
-  {% include links.html %}
+  {% include form-join.html %}
 </section>
 
 <section class="titled-block" aria-labelledby="hl-a11y">

--- a/join.md
+++ b/join.md
@@ -6,4 +6,4 @@ languages: ["en", "nl"]
 ---
 # {% t connect.info %}
 {% t connect.description %}
-{% include links.html %}
+{% include form-join.html %}

--- a/subscribe-redirect.md
+++ b/subscribe-redirect.md
@@ -16,5 +16,5 @@ Our volunteer team has received your information and will send you further infor
 In the meantime, join one of our [upcoming events](/events)! If you have any further questions, you can contact us at join@techwerkers.nl 
 
 ## Social media links
-{%include links.html %} 
+{%include form-join.html %} 
 

--- a/themes.md
+++ b/themes.md
@@ -111,6 +111,6 @@ permalink: /directory
 </ul>
 
 ## {% translate connect.info %}
-{% include links.html %}
+{% include form-join.html %}
 ## {% translate global.code_of_conduct.title %}
 {% translate global.code_of_conduct.summary %}


### PR DESCRIPTION
There are a few changes wrapped up in here.

* Remove CTA from Intro text to form which is on the same page when
  viewed on homepage. This link is broken when same text is used on
About page.
* Rename links.html => form-join.html to better communicate purpose
* Introduce newsletter checkbox (off by default)

Screengrab, showing new checkbox component based on existing form pattern of label / newline / input

![Screenshot 2024-07-03 at 11 07 56](https://github.com/techworkersco/twc-site-nl/assets/472589/18298855-2110-4c83-95fe-41279e112f27)

