### PR TITLE
Adding Dutch events so they can be consumed on mainstream website

### DIFF
--- a/events.yml
+++ b/events.yml
@@ -1,0 +1,12 @@
+---
+layout: null
+---
+{% for event in site.events %}
+- title: "{{event.title}}"
+  date: {{event.date}}
+  locations: [Netherlands]
+  tags: {{event.tags}} 
+  timeszones: [Europe/Amsterdam]
+  image: {{site.url}}{{event.image}}
+  url: {{site.url}}{{event.url}}
+{% endfor %}


### PR DESCRIPTION
This makes it possible to load events inside techworkerscoalition.org, when it is called in this loader https://github.com/techworkersco/twc-site/blob/master/_config.yml#L40 and https://github.com/techworkersco/twc-site/blob/f3dcf19642e5f149981f6091b6837184e50e5eed/_includes/events.html#L1