### PR TITLE
Introduce monthly dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,27 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: monthly
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: monthly
+    allow:
+      - dependency-type: 'all'
+    groups:
+      npm-deps:
+        patterns:
+          - '*'
+  - package-ecosystem: bundler
+    directory: '/'
+    schedule:
+      interval: monthly
+    allow:
+      - dependency-type: 'all'
+    groups:
+      bundler-deps:
+        patterns:
+          - '*'

--- a/.github/workflows/dependabot_automerge.yaml
+++ b/.github/workflows/dependabot_automerge.yaml
@@ -1,0 +1,39 @@
+name: Automerge Dependabot PRs
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Approve non-major version updates
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Enable auto-merge for non-major Dependabot PRs
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Requires: #26 

Reason for monthly: reduce dependency update noise. This is a static site, so updating things to be on the bleeding edge is less important

Security dependabots still get checked as and when they come out, even with monthly selected