### PR TITLE
Ignore events.yml for prettier - not needed

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+events.yml


### PR DESCRIPTION
Prettier doesn't like events.yml. It started failing recently, who knows why, but also we don't need it on that file (hopefully :sweat_smile:)