### PR TITLE
This enables us to enable branch protection

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,5 +1,8 @@
 local_backend: true # run `npx decap-server` to access /admin locally
 
+# enable PRs and status checks for main branch protection
+publish_mode: editorial_workflow
+
 backend:
   name: git-gateway
   branch: main # Branch to update (optional; defaults to master)

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -9,6 +9,7 @@ backend:
   accept_roles: #optional - accepts all users if left out
     - admin
     - editor
+  squash_merges: true # We are not super interested in the draft history
 
 media_folder: 'assets/img'
 


### PR DESCRIPTION
Docs are here: https://decapcms.org/docs/editorial-workflows/

TL;DR: This workflow enables drafts to be saved as pull requests, which can then be published (e.g. merges the PR). This means we can enable main push protection and status checks on PRs etc.