### PR TITLE
Rename Planning => Organizing and give a number

### DIFF
--- a/_events/biweekly-planning-meeting-10.md
+++ b/_events/biweekly-planning-meeting-10.md
@@ -1,5 +1,5 @@
 ---
-title: Biweekly Planning Meeting
+title: "Biweekly Organizing Meeting #10"
 date: 2024-11-18 18:00
 locations:
   - The Netherlands

--- a/_events/biweekly-planning-meeting-11.md
+++ b/_events/biweekly-planning-meeting-11.md
@@ -1,6 +1,6 @@
 ---
-title: Biweekly Planning Meeting
-date: 2024-11-18 18:00
+title: "Biweekly Organizing Meeting #11"
+date: 2024-12-02 18:00
 locations:
   - The Netherlands
 hide_form: false

--- a/_events/biweekly-planning-meeting-8.md
+++ b/_events/biweekly-planning-meeting-8.md
@@ -1,5 +1,5 @@
 ---
-title: Biweekly Planning Meeting
+title: "Biweekly Organizing Meeting #~8"
 date: 2024-10-21 18:00
 locations:
   - The Netherlands

--- a/_events/biweekly-planning-meeting-9.md
+++ b/_events/biweekly-planning-meeting-9.md
@@ -1,5 +1,5 @@
 ---
-title: Biweekly Planning Meeting
+title: "Biweekly Organizing Meeting #9"
 date: 2024-11-04 18:00
 locations:
   - The Netherlands


### PR DESCRIPTION
I know twc-site-berlin uses "General Meeting". Also feels nice.

I think "Organizing" feels like a nicer word than "Planning" personally.

Also, giving numbers to the meetings so it's easier to organise in the admin/githubs. I took a guess at ~8 for the first one.