### PR TITLE
(Fix) Button language-relative, update links on homepage

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -4,7 +4,7 @@ description: "Would you like more autonomy at work? Make it happen. Join today!"
 ---
 
 <span class="flex justify-center uppercase font-mono">
-  {{< button href="en/join" >}}
+  {{< button href="join" >}}
     Join
   {{< /button >}}
 </span>

--- a/content/_index.nl.md
+++ b/content/_index.nl.md
@@ -4,7 +4,7 @@ description: "Wil je meer autonomie op je werk? Maak het werkelijkheid. Sluit je
 ---
 
 <span class="flex justify-center uppercase font-mono">
-  {{< button href="nl/join" >}}
+  {{< button href="join" >}}
     Doe mee
   {{< /button >}}
 </span>

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -1,5 +1,4 @@
 {{ $base_url := .Site.BaseURL }}
-{{ $lang := .Site.Language.Lang }}
 <a
   class="rounded-md bg-primary-600 px-4 py-2 text-neutral no-underline hover:bg-primary-500 hover:rounded-md"
   {{ with .Get "href" }}href="{{ . | relLangURL }}"{{ end }}

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -2,7 +2,7 @@
 {{ $lang := .Site.Language.Lang }}
 <a
   class="rounded-md bg-primary-600 px-4 py-2 text-neutral no-underline hover:bg-primary-500 hover:rounded-md"
-  {{ with .Get "href" }}href="{{ $base_url }}{{ $lang }}{{ . | relURL }}"{{ end }}
+  {{ with .Get "href" }}href="{{ . | relLangURL }}"{{ end }}
   {{ with .Get "target" }}target="{{ . }}"{{ end }}
   {{ with .Get "download" }}download="{{ . }}"{{ end }}
   role="button"

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -1,7 +1,8 @@
 {{ $base_url := .Site.BaseURL }}
+{{ $lang := .Site.Language.Lang }}
 <a
   class="rounded-md bg-primary-600 px-4 py-2 text-neutral no-underline hover:bg-primary-500 hover:rounded-md"
-  {{ with .Get "href" }}href="{{ $base_url }}{{ . }}"{{ end }}
+  {{ with .Get "href" }}href="{{ $base_url }}{{ $lang }}{{ . | relURL }}"{{ end }}
   {{ with .Get "target" }}target="{{ . }}"{{ end }}
   {{ with .Get "download" }}download="{{ . }}"{{ end }}
   role="button"


### PR DESCRIPTION
This change: 
- Updates the `button` shortcode, such that the link that you specify when the shortcode is used is language-relative, and you don't need to add a prefix to a specific language.
- Removes language-specific prefixes on two pages on which the button shortcode was used.