### PR TITLE
Add join success landing page

### DIFF
--- a/content/join-success/index.en.md
+++ b/content/join-success/index.en.md
@@ -1,0 +1,16 @@
+---
+title: "Congrats 🥳"
+description: "You're joining the Tech Workers Coalition! Together we can take collective action and change tech work in the Netherlands for the better."
+layout: "join-success"
+---
+
+## What happens next?
+
+You've taken the first step. Here's what happens next:
+
+1. You're automatically subscribed to the Tech Workers Coalition newsletter with updates on meetups, trainings, and actions. 
+2. You'll get invited to the Tech Workers Coalition Slack, where you can meet fellow tech workers from all over the world 🌍
+
+In the meantime, join one of the [upcoming events](events). 
+
+Do you have any questions? Feel free to reach out via email (`hey@techwerkers.nl`) or through one of our socials.

--- a/content/join-success/index.nl.md
+++ b/content/join-success/index.nl.md
@@ -1,0 +1,16 @@
+---
+title: "Goed bezig 🥳"
+description: "Je komt bij Techwerkers! Samen kunnen we techwerk in Nederland beter maken, op de manier die jij wilt."
+layout: "join-success"
+---
+
+## Wat nu?
+
+Je hebt de eerste stap gezet. Zo gaat het verder:
+
+1. Je wordt automatisch toegevoegd aan de Techwerkersnieuwsbrief met info over bijeenkomsten, trainingen en acties. 
+2. Je wordt uitgenodigd voor de *Tech Workers Coalition* Slack (Engelstalig), waar je techwerkers van over de hele wereld kunt ontmoeten 🌍
+
+In de tussentijd ben je ook zeer welkom op een van de [aankomende activiteiten](events). 
+
+Heb je nog vragen? Neem gerust contact op via email (`hey@techwerkers.nl`) of sociale media.

--- a/layouts/_default/join-success.html
+++ b/layouts/_default/join-success.html
@@ -1,0 +1,18 @@
+{{ define "main" }}
+  <article class="max-w-5xl mx-auto">
+    <header>
+      {{ if .Params.showBreadcrumbs | default (.Site.Params.article.showBreadcrumbs | default false) }}
+        {{ partial "breadcrumbs.html" . }}
+      {{ end }}
+      <h1 class="mt-0 text-4xl font-extrabold text-neutral-900">
+        {{ .Title | emojify }}
+      </h1>
+    </header>
+    <section class="prose mt-6 max-w-full">
+        <div class="lead max-w-4xl">
+            {{ .Page.Params.description }}
+        </div>
+      {{ .Content | emojify }}
+    </section>
+  </article>
+{{ end }}

--- a/layouts/partials/join-form.html
+++ b/layouts/partials/join-form.html
@@ -3,7 +3,7 @@
   name="subscribe"
   class="max-w-2xl ml-0 mt-4 bg-red-600 rounded-lg"
   data-netlify="true"
-  action="{{ relLangURL "welcome" }}"
+  action="{{ relLangURL "join-success" }}"
 >
   <h3 class="text-2xl font-bold text-gray-900 mt-10">{{ i18n "join-form" }}</h3>
   <p class="my-6 text-gray-600">{{ i18n "join-description" }}</p>


### PR DESCRIPTION
This change: 
- Adds a layout (`join-success`) for a landing page that the tech worker will land on once they've filled out the **Join** form
- Adds EN and NL post-join landing pages that use the `join-success` layout, with some info about next steps now that the tech worker has completed the form 

**TO DO:**
Setting this to **Draft** as I wasn't sure how to connect the success state of the form with this landing page? Any thoughts welcome or feel free to edit directly 🙂 