### PR TITLE
Redirect all root non-language resources to lang child

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,13 +23,6 @@
 # Root domain redirect based on Accept header
 [[redirects]]
   from = "/"
-  to = "/nl/"
-  status = 301
-  force = true
-  conditions = {Language = "nl"}
-
-[[redirects]]
-  from = "/"
   to = "/en/"
   status = 301
   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,6 +21,7 @@
   force = true
 
 # Root domain redirect based on Accept header
+# Netlify only redirects on first lang. NL is the default otherwise.
 [[redirects]]
   from = "/"
   to = "/en/"
@@ -28,7 +29,6 @@
   force = true
   conditions = {Language = "en"}
 
-# Default root domain redirect
 [[redirects]]
   from = "/"
   to = "/nl/"
@@ -44,6 +44,6 @@
   status = 404
 
 [[redirects]]
-  from = "/nl/*"
+  from = "/*"
   to = "/nl/404.html"
   status = 404

--- a/netlify.toml
+++ b/netlify.toml
@@ -35,6 +35,49 @@
   status = 301
   force = true
 
+# Root Redirects for localised content types.
+# Netlify splat operator cannot be used on root due to it redirecting FE assets
+# Adding new content types:
+#  - There should be a pair of "en" and "default" (nl) for each content type
+[[redirects]]
+  from = "/events"
+  to = "/en/events"
+  status = 301
+  force = true
+  conditions = {Language = "en"}
+
+[[redirects]]
+  from = "/events"
+  to = "/nl/events"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/join"
+  to = "/en/join"
+  status = 301
+  force = true
+  conditions = {Language = "en"}
+
+[[redirects]]
+  from = "/join"
+  to = "/nl/join"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/resources"
+  to = "/en/resources"
+  status = 301
+  force = true
+  conditions = {Language = "en"}
+
+[[redirects]]
+  from = "/resources"
+  to = "/nl/resources"
+  status = 301
+  force = true
+
 # Localised 404 redirects
 # Netlify shadowing means that pages that do exist behind the * will render if they exist
 #   otherwise they will return the referenced 404.


### PR DESCRIPTION
In this PR:

- Fix the 404 on the root page. e.g. https://techwerkers.nl/meow
- `nl ` is the default, so we only need redirects for `Accept-Language: en`

Note:

- We don't redirect /events/*, but realisitically we don't need to. These urls would be copy/pasted from person to person - e.g. no one is going accidentally type one of these event slugs by hand.
- `events` and `resources` and  `join` are the only root redirected paths at present. We need to remember to add more if we have more content types that people may type in.
- The default 404 is in dutch because that is the primary language of the site.

## Tests

Chrome settings -> Search: Language -> Add dutch if not already there.

Note 1: Netlify only looks at the first language, so even if the language order is `fr,en`, it will give `nl` because that is the default, and english wasn't first.
Note 2: If the language order is `en,nl` the user will get the english site, not the NL site. This is pretty hard to change unless we write netlify edge functions etc.

Tests below are `Accept-Language` header lang order => result

| Path | Accept-Language Header | Result |
| - | - | - |
| /en/ | * | /en/ |
| /nl/ | * | /nl/ |
| / | en | /en/ |
| / | pl,en | /nl/ |
| / | nl | /nl/ |
| / | null | /nl/ |
| /events/ | en | /en/events/ |
| /events/ | po,en | /nl/events/ |
| /events/ | nl | /nl/events/ |
| /events/2025-02-13/training/ | anything | /nl/404 |
| /meow | en | /nl/404 |
| /meow | nl | /nl/404 |
| /en/meow | * | /en/404 |
