### PR TITLE
Add feature image support to decap cms

### DIFF
--- a/content/resources/cao/index.en.md
+++ b/content/resources/cao/index.en.md
@@ -5,6 +5,7 @@ lastmod: "2025-01-22"
 description: "As a tech worker in the Netherlands, you may run into collective labour agreements (CAOs). But what is a collective labour agreement? How does it work? What's in it? Here's the basics on collective labour agreements in the Netherlands."
 tags: ["rights"]
 layout: "single-resource"
+feature: "feature-office-celebration.jpg"
 ---
 
 ## Terminology

--- a/content/resources/cao/index.nl.md
+++ b/content/resources/cao/index.nl.md
@@ -5,6 +5,7 @@ lastmod: "2025-01-22"
 description: "Als techwerker kom je misschien wel eens collectieve arbeidsovereenkomsten (cao's) tegen. Maar hoe werkt een cao? Wat staat erin? Hier de basis over cao's in Nederland."
 tags: ["rechten"]
 layout: "single-resource"
+feature: "feature-office-celebration.jpg"
 ---
 
 ## Begrippen

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -55,6 +55,17 @@ collections:
         name: description
         widget: text
         i18n: true
+      - label: Feature Image
+        name: feature
+        widget: image
+        allow_multiple: false
+        i18n: true
+        choose_url: true
+      - label: Feature Image Alt Text
+        name: featureAlt
+        widget: string
+        i18n: true
+        required: false
       - label: Created Date
         name: date
         widget: datetime
@@ -63,6 +74,7 @@ collections:
         name: lastmod
         widget: datetime
         i18n: duplicate
+        required: false
       - label: Tags
         name: tags
         widget: list


### PR DESCRIPTION
When adding decap in #62 I missed the feature image selector. Hugo is nice enough to detect "feature-*" as the feature image, but this will let people upload files directly via the CMS instead without having to rely on filenames.

Also, minor tweak to make last modified date to not be required.

![Screenshot_20250216_095953](https://github.com/user-attachments/assets/d4158cf2-fba9-4ae2-8413-d002d1975a05)

Can be accessed here too: https://deploy-preview-66--twc-site-nl.netlify.app/admin/#/ (Note, the image won't show up since decap is accessing the resources from `main` instead of from this branch).