### PR TITLE
Add bluesky, mastodon socials to footer

### DIFF
--- a/config/_default/languages.en.toml
+++ b/config/_default/languages.en.toml
@@ -20,8 +20,8 @@ copyright = "2025 Tech Workers Coalition"
   links = [
     { instagram = "https://instagram.com/techwerkers" },
     # { linkedin = "" },
-    # { bluesky = "https://bsky.app/profile/techwerkers.bsky.social" },
+    { bluesky = "https://bsky.app/profile/techwerkers.bsky.social" },
     # { x-twitter = "" },
-    # { mastodon = "" },
+    { mastodon = "https://mastodon.nl/@techwerkers" },
     { email = "mailto:hey@techwerkers.nl" },
   ]

--- a/config/_default/languages.nl.toml
+++ b/config/_default/languages.nl.toml
@@ -20,9 +20,9 @@ copyright = "2025 Techwerkers"
   links = [
     { instagram = "https://instagram.com/techwerkers" },
     # { linkedin = "" },
-    # { bluesky = "https://bsky.app/profile/techwerkers.bsky.social" },
+    { bluesky = "https://bsky.app/profile/techwerkers.bsky.social" },
     # { x-twitter = "" },
-    # { mastodon = "" },
+    { mastodon = "https://mastodon.nl/@techwerkers" },
     { email = "mailto:hey@techwerkers.nl" },
   ]
 


### PR DESCRIPTION
This change adds the social links to our Mastodon & Bluesky accounts to the footer.