### PR TITLE
Use different backend for CMS

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -3,11 +3,9 @@ local_backend: true
 publish_mode: editorial_workflow
 
 backend:
-  name: git-gateway
+  name: github
+  repo: techworkersco/twc-site-nl
   branch: main
-  accept_roles:
-    - admin
-    - editor
   # we don't need draft history
   squash_merges: true
 

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -8,6 +8,8 @@ backend:
   branch: main
   # we don't need draft history
   squash_merges: true
+  # Let external people fork and submit PRs
+  open_authoring: true
 
 media_folder: static/img
 public_folder: /img


### PR DESCRIPTION
git-gateway looks deprecated by netlify: https://docs.netlify.com/security/secure-access-to-sites/git-gateway/

The way it worked: We stored a PAT token in netlify. When people logged into the CMS, they were logging into netlify. Netlify would then use that PAT token to commit the changes. This meant we could give people access to netlify, instead of the git repo. It also meant people didn't have to have a git account. Reality is that the editing group likely isn't large, and we can get those people to create github accounts.

Also: Enable open authoring. Forks and commits PRs for anyone: https://decapcms.org/docs/open-authoring/

:point_up: This will mean anyone can go to https://techwerkers.nl/admin, and they will be able to create new records. It will fork the repo into their github account, make the changes, and PR in the background - very cool. I doubt we'll "need" that so much, but it's a "nice to have".


