### PR TITLE
Add events.yaml for global site

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,5 +10,8 @@
 #/exampleSite/content/docs/version-2/lighthouse.html
 # UPSTREAM-->
 
+# yaml formats :shrug:
+/layouts/_default/events.yaml
+
 # TODO: See if we can remove these ignores
 /layouts/_partials/resource-link.html

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -15,3 +15,19 @@ summaryLength = 0
 
 [outputs]
   home = ["HTML", "RSS", "JSON"]
+
+[outputFormats]
+  [outputFormats.yaml]
+    baseName = 'index'
+    isHTML = false
+    isPlainText = true
+    mediaType = 'application/yaml'
+    noUgly = true
+    notAlternative = true
+    path = ''
+    permalinkable = false
+    protocol = ''
+    rel = ''
+    root = false
+    ugly = false
+    weight = 0

--- a/content/events/2025-04-07/index.en.md
+++ b/content/events/2025-04-07/index.en.md
@@ -1,6 +1,6 @@
 ---
 title: "Organizing meetup"
-date: 2025-04-07T18:00:00+01:00
+date: 2025-04-07T18:00:00+02:00
 location: "Online"
 organisation: ""
 tags: ["organizing"]

--- a/content/events/2025-04-07/index.nl.md
+++ b/content/events/2025-04-07/index.nl.md
@@ -1,6 +1,6 @@
 ---
 title: "Organisatiebijeenkomst"
-date: 2025-04-07T18:00:00+01:00
+date: 2025-04-07T18:00:00+02:00
 location: "Online"
 organisation: ""
 tags: ["organisatie"]

--- a/content/events/2025-04-08/index.en.md
+++ b/content/events/2025-04-08/index.en.md
@@ -1,9 +1,10 @@
 ---
 title: "Shaping radical technologies"
-date: 2025-04-08T17:30:00+01:00
+date: 2025-04-08T17:30:00+02:00
 location: "VU StudentenD0k, de Boelelaan 1105, Amsterdam"
 organisation: ""
 tags: []
+feature: "feature-rosa.jpg"
 ---
 
 Have you ever wondered how capitalism influences technological developments? What is the meaning of digital colonialism? What is the role of workers in the modern tech industry, and how we can unite and fight for liberation in the digital age?

--- a/content/events/2025-04-08/index.nl.md
+++ b/content/events/2025-04-08/index.nl.md
@@ -1,9 +1,10 @@
 ---
 title: "Radicale technologieën vormgeven"
-date: 2025-04-08T17:30:00+01:00
+date: 2025-04-08T17:30:00+02:00
 location: "VU StudentenD0k, de Boelelaan 1105, Amsterdam"
 organisation: ""
 tags: [""]
+feature: "feature-rosa.jpg"
 ---
 
 Heb je je ooit afgevraagd hoe kapitalisme technologische ontwikkelingen beïnvloedt? Wat digitaal kolonialisme betekent? Wat de is rol van werknemers in de moderne tech-industrie, en hoe je je kunt verenigen om te vechten voor bevrijding in het digitale tijdperk?

--- a/content/events/2025-04-11/index.en.md
+++ b/content/events/2025-04-11/index.en.md
@@ -1,9 +1,10 @@
 ---
 title: "Tech workers conference Berlin"
-date: 2025-04-11T9:00:00+01:00
+date: 2025-04-11T9:00:00+02:00
 location: "Berlin"
 organisation: ""
 tags: [""]
+feature: "feature-conference.jpg"
 ---
 
 Tech worker comrades in Berlin are organizing a conference, and you're invited!

--- a/content/events/2025-04-11/index.nl.md
+++ b/content/events/2025-04-11/index.nl.md
@@ -1,9 +1,10 @@
 ---
 title: "Techwerkerconferentie Berlijn"
-date: 2025-04-11T9:00:00+01:00
+date: 2025-04-11T9:00:00+02:00
 location: "Berlijn"
 organisation: ""
 tags: [""]
+feature: "feature-conference.jpg"
 ---
 
 Techwerkerkameraden in Berlijn organiseren een conferentie, en jij bent uitgenodigd!

--- a/content/events/2025-04-15/index.en.md
+++ b/content/events/2025-04-15/index.en.md
@@ -1,9 +1,10 @@
 ---
 title: "Tech Workers Coalition onboarding"
-date: 2025-04-15T17:00:00+01:00
+date: 2025-04-15T17:00:00+02:00
 location: "Online"
 organisation: ""
 tags: ["organizing"]
+feature: "feature-onboarding.jpg"
 ---
 
 Would you like to learn more about the Tech Workers Coalition? Want to get more involved? Join the Tech Workers Coalition onboarding call on 15 April!

--- a/content/events/2025-04-15/index.nl.md
+++ b/content/events/2025-04-15/index.nl.md
@@ -1,9 +1,10 @@
 ---
 title: "Introductie op de Techwerkerscoalitie (Engelstalig)"
-date: 2025-04-15T17:00:00+01:00
+date: 2025-04-15T17:00:00+02:00
 location: "Online"
 organisation: ""
 tags: []
+feature: "feature-onboarding.jpg"
 ---
 
 Wil je meer weten over Techwerkers? Ben je benieuwd wat je zelf kunt doen? Kom dan naar de Techwerkers introductiebijeenkomst (Engelstalig) op 15 april!

--- a/content/events/2025-04-21/index.en.md
+++ b/content/events/2025-04-21/index.en.md
@@ -1,6 +1,6 @@
 ---
 title: "Organizing meetup"
-date: 2025-04-21T18:00:00+01:00
+date: 2025-04-21T18:00:00+02:00
 location: "Online"
 organisation: ""
 tags: ["organizing"]

--- a/content/events/2025-04-21/index.nl.md
+++ b/content/events/2025-04-21/index.nl.md
@@ -1,6 +1,6 @@
 ---
 title: "Organisatiebijeenkomst"
-date: 2025-04-21T18:00:00+01:00
+date: 2025-04-21T18:00:00+02:00
 location: "Online"
 organisation: ""
 tags: ["organisatie"]

--- a/content/events/2025-04-23/index.en.md
+++ b/content/events/2025-04-23/index.en.md
@@ -5,6 +5,8 @@ location: "Online"
 description: "An online info session for Booking.com workers about organizing against layoffs"
 organisation: ""
 tags: ["organizing"]
+feature: feature-booking.png
+featureAlt: "A flyer for the Booking.com layoff session"
 showTableOfContents: false
 ---
 

--- a/content/events/2025-04-23/index.nl.md
+++ b/content/events/2025-04-23/index.nl.md
@@ -5,6 +5,7 @@ location: "Online"
 description: "Een online infosessie voor Booking.com-medewerkers over organiseren tegen massa-ontslagen"
 organisation: ""
 tags: ["organizeren"]
+feature: feature-booking.png
 showTableOfContents: false
 ---
 

--- a/content/events/2025-04-25/index.en.md
+++ b/content/events/2025-04-25/index.en.md
@@ -5,6 +5,8 @@ description: "An online info session for Booking.com workers about organizing ag
 location: "Online"
 organisation: ""
 tags: ["organizing"]
+feature: feature-booking.png
+featureAlt: "A flyer for the Booking.com layoff session"
 showTableOfContents: false
 ---
 

--- a/content/events/2025-04-25/index.nl.md
+++ b/content/events/2025-04-25/index.nl.md
@@ -5,6 +5,7 @@ description: "Een online infosessie voor Booking.com-medewerkers over organisere
 location: "Online"
 organisation: ""
 tags: ["organizeren"]
+feature: feature-booking.png
 showTableOfContents: false
 ---
 

--- a/content/events/2025-05-01/index.en.md
+++ b/content/events/2025-05-01/index.en.md
@@ -1,6 +1,6 @@
 ---
 title: "Labour day"
-date: 2025-05-01T14:00:00+01:00
+date: 2025-05-01T14:00:00+02:00
 location: "Museumplein, Amsterdam"
 organisation: ""
 tags: [""]

--- a/content/events/2025-05-01/index.nl.md
+++ b/content/events/2025-05-01/index.nl.md
@@ -1,6 +1,6 @@
 ---
 title: "Dag van de arbeid"
-date: 2025-05-01T14:00:00+01:00
+date: 2025-05-01T14:00:00+02:00
 location: "Museumplein, Amsterdam"
 organisation: ""
 tags: [""]

--- a/content/events/2025-05-19/index.en.md
+++ b/content/events/2025-05-19/index.en.md
@@ -1,6 +1,6 @@
 ---
 title: "Organizing meetup"
-date: 2025-05-19T18:00:00+01:00
+date: 2025-05-19T18:00:00+02:00
 location: "Online"
 organisation: ""
 tags: ["organizing"]

--- a/content/events/2025-05-19/index.nl.md
+++ b/content/events/2025-05-19/index.nl.md
@@ -1,6 +1,6 @@
 ---
 title: "Organisatiebijeenkomst"
-date: 2025-05-19T18:00:00+01:00
+date: 2025-05-19T18:00:00+02:00
 location: "Online"
 organisation: ""
 tags: ["organisatie"]

--- a/content/events/_index.en.md
+++ b/content/events/_index.en.md
@@ -2,6 +2,8 @@
 title: "Events"
 description: ""
 index: true
+layout: "events"
+outputs: ["HTML", "RSS", "YAML"]
 ---
 
 {{< lead >}}

--- a/content/events/_index.nl.md
+++ b/content/events/_index.nl.md
@@ -2,6 +2,8 @@
 title: "Activiteiten"
 description: ""
 index: true
+layout: "events"
+outputs: ["HTML", "RSS", "YAML"]
 ---
 
 {{< lead >}}

--- a/layouts/_default/events.yaml
+++ b/layouts/_default/events.yaml
@@ -1,0 +1,18 @@
+{{- $events := .Site.GetPage "events" -}}
+---
+events:
+{{- range sort $events.Pages ".Date" "asc" -}}
+{{- $images := .Resources.ByType "image" }}
+{{- $feature := $images.GetMatch .Params.feature }}
+- title: {{ .Params.title }}
+  date: {{ .Date.Format "2006-01-02T15:04:05Z07:00" }}
+  location: {{ .Params.location }}
+  tags: {{ .Params.tags }}
+  timezones: ["{{ .Date.Format "MST"}}"]
+  {{- with $feature }}
+  image: {{ .Permalink }}
+  {{- else }}
+  image: {{ .Site.BaseURL }}img/logo-{{ .Lang }}.png
+  {{- end }}
+  url: {{ .Permalink }}
+{{- end -}}

--- a/layouts/_default/events.yaml
+++ b/layouts/_default/events.yaml
@@ -2,10 +2,10 @@
 {{- range sort $events ".Date" "asc" -}}
 {{- $images := .Resources.ByType "image" -}}
 {{- $feature := $images.GetMatch .Params.feature }}
-- title: {{ .Params.title }}
+- title: {{ .Params.title | jsonify }}
   date: {{ .Date.Format "2006-01-02 15:04:05 -07:00" }}
-  location: {{ .Params.location }}
-  tags: {{ .Params.tags }}
+  locations: [{{ .Params.location | jsonify }}]
+  tags: {{ .Params.tags | jsonify }}
   timezones: ["Europe/Amsterdam"]
   {{- with $feature }}
   image: {{ .Permalink }}

--- a/layouts/_default/events.yaml
+++ b/layouts/_default/events.yaml
@@ -1,14 +1,12 @@
-{{- $events := .Site.GetPage "events" -}}
----
-events:
-{{- range sort $events.Pages ".Date" "asc" -}}
-{{- $images := .Resources.ByType "image" }}
+{{- $events := (.Site.GetPage "events").Pages -}}
+{{- range sort $events ".Date" "asc" -}}
+{{- $images := .Resources.ByType "image" -}}
 {{- $feature := $images.GetMatch .Params.feature }}
 - title: {{ .Params.title }}
-  date: {{ .Date.Format "2006-01-02T15:04:05Z07:00" }}
+  date: {{ .Date.Format "2006-01-02 15:04:05 -07:00" }}
   location: {{ .Params.location }}
   tags: {{ .Params.tags }}
-  timezones: ["{{ .Date.Format "MST"}}"]
+  timezones: ["Europe/Amsterdam"]
   {{- with $feature }}
   image: {{ .Permalink }}
   {{- else }}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -118,6 +118,18 @@ collections:
         i18n: true
         default: []
         allow_add: true
+      - label: Feature Image
+        name: feature
+        widget: image
+        allow_multiple: false
+        i18n: true
+        choose_url: true
+        required: false
+      - label: Feature Image Alt Text
+        name: featureAlt
+        widget: string
+        i18n: true
+        required: false
       - label: Body
         name: body
         widget: markdown


### PR DESCRIPTION
Lots of "TIL" for me here.

Hugo wants to have output formats "per content". e.g. we have a main _index collection page for events, and current we render this in HTML (and also JSON, and RSS xml aswell!)

So what we "needed" here is a new output format for yaml - and then telling the events page we also want to have a YAML output. We could define yaml output for the entire site, however hugo starts to complain since we don't have a global yaml. Fun facts: https://techwerkers.nl/en/index.xml <-- we have a RSS feed for our homepage at present :sweat_smile: 

So this PR:
- [x] adds a new yaml output format
- [x] tells the event page to output a yaml page as well as html and rss (which we already have)
- [x] includes a specific yaml layout for the events page (which makes sense because it's different frontmatter etc)

And bonuses:
- [x] fixes some event timezones, they should have been +02:00
- [x] adds CMS feature image support :rocket: 

:brain: At some point in the future we could enable an `ics` output format. Then we could actually render an `ics` (calendar) file for each event, and put a link on the page for people to add it to their calendars :sweat_smile: (The hard part is we only want `ics` for each event, and that means adding an output array for each event, maybe some hacky ways to do this, who knows).

I also just stumbled across this: https://discourse.gohugo.io/t/custom-layout-for-certain-content-types/3193 which might be an easier way to do layouts per content type :shrug:.