### PR TITLE
Add upcoming organizing events

### DIFF
--- a/content/events/2025-05-12/index.en.md
+++ b/content/events/2025-05-12/index.en.md
@@ -1,0 +1,9 @@
+---
+title: "Organizing meetup"
+date: 2025-05-12T18:00:00+02:00
+location: "Online"
+organisation: ""
+tags: ["organizing"]
+---
+
+Tech Workers Coalition Netherlands' fortnightly action planning meeting. [Join](/en/join) if you'd like to take part!

--- a/content/events/2025-05-12/index.nl.md
+++ b/content/events/2025-05-12/index.nl.md
@@ -1,0 +1,9 @@
+---
+title: "Organisatiebijeenkomst"
+date: 2025-05-12T18:00:00+02:00
+location: "Online"
+organisation: ""
+tags: ["organisatie"]
+---
+
+De tweewekelijkse planbijeenkomst van Techwerkers. [Sluit je aan](/join) als je mee wilt doen!

--- a/content/events/2025-05-26/index.en.md
+++ b/content/events/2025-05-26/index.en.md
@@ -1,0 +1,9 @@
+---
+title: "Organizing meetup"
+date: 2025-05-26T18:00:00+02:00
+location: "Online"
+organisation: ""
+tags: ["organizing"]
+---
+
+Tech Workers Coalition Netherlands' fortnightly action planning meeting. [Join](/en/join) if you'd like to take part!

--- a/content/events/2025-05-26/index.nl.md
+++ b/content/events/2025-05-26/index.nl.md
@@ -1,6 +1,6 @@
 ---
 title: "Organisatiebijeenkomst"
-date: 2025-05-19T18:00:00+02:00
+date: 2025-05-26T18:00:00+02:00
 location: "Online"
 organisation: ""
 tags: ["organisatie"]

--- a/content/events/2025-06-09/index.en.md
+++ b/content/events/2025-06-09/index.en.md
@@ -1,6 +1,6 @@
 ---
 title: "Organizing meetup"
-date: 2025-05-19T18:00:00+02:00
+date: 2025-06-09T18:00:00+02:00
 location: "Online"
 organisation: ""
 tags: ["organizing"]

--- a/content/events/2025-06-09/index.nl.md
+++ b/content/events/2025-06-09/index.nl.md
@@ -1,0 +1,9 @@
+---
+title: "Organisatiebijeenkomst"
+date: 2025-06-09T18:00:00+02:00
+location: "Online"
+organisation: ""
+tags: ["organisatie"]
+---
+
+De tweewekelijkse planbijeenkomst van Techwerkers. [Sluit je aan](/join) als je mee wilt doen!


### PR DESCRIPTION
This change adds events for organizing meetups on 12 and 26 May, and 9 June, to keep the events list populated. Merging w/o review as it just adds more events of the same type that we already have in the calendar many times.