### PR TITLE
Ignore content for prettier, decap and prettier don't play togethermn

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,5 +16,5 @@
 # TODO: See if we can remove these ignores
 /layouts/_partials/resource-link.html
 
-# Ignore any posts because they're likely to be from the CMS
-/content/posts/
+# Ignore any content because its possible it comes from the CMS
+/content/


### PR DESCRIPTION
There isn't any way to control the output of the content from decap, and it all "Just works" normally. And it looks like there isn't a way to configure decap output frontmatter to be prettier compliant, so :shrug:.

Alternative is to get prettier to just run from a github action and commit itself, but meh? It's a bit of messing around for not much benefit, so if someone else is keen to make that work, all good.