### PR TITLE
feat/home page news

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -26,11 +26,6 @@
   weight = 30
 
 [[main]]
-  name = "News"
-  pageRef = "posts"
-  weight = 40
-
-[[main]]
   name = "Join"
   pageRef = "join"
   weight = 50

--- a/config/_default/menus.nl.toml
+++ b/config/_default/menus.nl.toml
@@ -26,11 +26,6 @@
   weight = 30
 
 [[main]]
-  name = "Nieuws"
-  pageRef = "posts"
-  weight = 40
-
-[[main]]
   name = "Doe mee"
   pageRef = "join"
   weight = 50

--- a/content/posts/dag-van-de-arbeid-looptocht-1-mei-2025/index.en.md
+++ b/content/posts/dag-van-de-arbeid-looptocht-1-mei-2025/index.en.md
@@ -1,11 +1,13 @@
 ---
 title: Labour day walk - 1 May 2025
-description: Tech workers represent in person at the Labour Day walk in Amsterdam
+summary: Tech workers represent in person at the Labour Day walk in Amsterdam
+showSummary: true
 author: Ben
 date: 2025-05-08T12:00:00+02:00
 tags: []
 feature: whatsapp-image-2025-05-01-at-15.45.02.jpeg
-featureAlt: Tech workers stand on a grassy field at Museumplein Amsterdam showing flags for Tech Workers Coalition
+featureAlt: Tech workers stand on a grassy field at Museumplein Amsterdam
+  showing flags for Tech Workers Coalition
 ---
 1 May is not a public holiday in The Netherlands. Yet that didn't stop a number of collaborators from Tech Workers Coalition showing up at the FNV Union's [Labour Day manifestation](https://www.fnv.nl/acties/dag-van-de-arbeid) in Amsterdam. The event started at Museumplein at 1pm, where flags were flown and tech workers showed up to support the day. Around 9000 people strong, the crowd then walked at 2pm from Museumplein to Martin Luther Kingpark, arriving at 4pm. FNV had additional festivities which tech workers attended.
 

--- a/content/posts/dag-van-de-arbeid-looptocht-1-mei-2025/index.en.md
+++ b/content/posts/dag-van-de-arbeid-looptocht-1-mei-2025/index.en.md
@@ -1,6 +1,6 @@
 ---
 title: Labour day walk - 1 May 2025
-summary: Tech workers represent in person at the Labour Day walk in Amsterdam
+summary: Tech workers represent in person at the Labour Day walk in Amsterdam.
 showSummary: true
 author: Ben
 date: 2025-05-08T12:00:00+02:00

--- a/content/posts/dag-van-de-arbeid-looptocht-1-mei-2025/index.nl.md
+++ b/content/posts/dag-van-de-arbeid-looptocht-1-mei-2025/index.nl.md
@@ -1,7 +1,6 @@
 ---
 title: Dag van de arbeid-parade - 1 Mei 2025
-summary: Techwerkers zijn persoonlijk aanwezig bij de Dag van de Arbeid-parade
-  in Amsterdam
+summary: Techwerkers zijn persoonlijk aanwezig bij de Dag van de Arbeid-parade in Amsterdam.
 showSummary: true
 author: Ben
 date: 2025-05-08T12:00:00+02:00

--- a/content/posts/dag-van-de-arbeid-looptocht-1-mei-2025/index.nl.md
+++ b/content/posts/dag-van-de-arbeid-looptocht-1-mei-2025/index.nl.md
@@ -1,11 +1,14 @@
 ---
 title: Dag van de arbeid-parade - 1 Mei 2025
-description: Techwerkers zijn persoonlijk aanwezig bij de Dag van de Arbeid-parade in Amsterdam
+summary: Techwerkers zijn persoonlijk aanwezig bij de Dag van de Arbeid-parade
+  in Amsterdam
+showSummary: true
 author: Ben
 date: 2025-05-08T12:00:00+02:00
 tags: []
 feature: whatsapp-image-2025-05-01-at-15.45.02.jpeg
-featureAlt: Techwerkers staan op een grasveld op het Museumplein in Amsterdam en tonen vlaggen van Tech Workers Coalition.
+featureAlt: Techwerkers staan op een grasveld op het Museumplein in Amsterdam en
+  tonen vlaggen van Tech Workers Coalition.
 ---
 1 mei is geen officiële feestdag in Nederland. Toch weerhield dat een aantal techwerkers er niet van om naar de [Dag van de Arbeid-manifestatie](https://www.fnv.nl/acties/dag-van-de-arbeid) van de FNV in Amsterdam te komen. Het evenement begon om 13.00 uur op het Museumplein, waar vlaggen wapperden en techwerkers aanwezig waren om hun steun voor de georganiseerde arbeid te tonen. Een stoet van zo'n 9000 mensen vertrok om 14.00 uur van het Museumplein naar het Martin Luther Kingpark, waar ze om 16.00 uur aankwam. De FNV had nog extra festiviteiten georganiseerd waar techwerkers aan deelnamen.
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -36,6 +36,8 @@
   translation: "Submit"
 - id: show-all
   translation: "Show all"
+- id: show-more
+  translation: "Show more"
 - id: show-resources
   translation: "Show all resources"
 - id: read-more

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -52,3 +52,9 @@
   translation: "Featured"
 - id: resources-description
   translation: "Guides and resources for tech workers."
+- id: recent-posts
+  translation: "Recent news"
+- id: posts
+  translation: "news"
+- id: post-description
+  translation: "News and updates relevant to tech workers"

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -36,6 +36,8 @@
   translation: "Verstuur"
 - id: show-all
   translation: "Toon alle"
+- id: show-more
+  translation: "Toon meer"
 - id: show-resources
   translation: "Naar de kennisbank"
 - id: read-more
@@ -53,7 +55,7 @@
 - id: resources-description
   translation: "Handige info voor techwerkers."
 - id: recent-posts
-  translation: "Recent nieuws"
+  translation: "Laatste nieuws"
 - id: posts
   translation: "nieuws"
 - id: post-description

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -52,3 +52,9 @@
   translation: "Uitgelicht"
 - id: resources-description
   translation: "Handige info voor techwerkers."
+- id: recent-posts
+  translation: "Recent nieuws"
+- id: posts
+  translation: "nieuws"
+- id: post-description
+  translation: "Nieuws en updaten relevant voor techwerkers"

--- a/layouts/_partials/home/page.html
+++ b/layouts/_partials/home/page.html
@@ -26,11 +26,11 @@
 </section>
 
 <section class="not-prose">
-  {{ partial "events-upcoming.html" . }}
+  {{ partial "recent-posts.html" . }}
 </section>
 
 <section class="not-prose">
-  {{ partial "recent-posts.html" . }}
+  {{ partial "events-upcoming.html" . }}
 </section>
 
 <section class="not-prose">

--- a/layouts/_partials/home/page.html
+++ b/layouts/_partials/home/page.html
@@ -30,5 +30,9 @@
 </section>
 
 <section class="not-prose">
+  {{ partial "recent-posts.html" . }}
+</section>
+
+<section class="not-prose">
   {{ partial "recent-resources.html" . }}
 </section>

--- a/layouts/_partials/recent-articles.html
+++ b/layouts/_partials/recent-articles.html
@@ -1,8 +1,0 @@
-{{ if .Site.Params.homepage.showRecent | default false }}
-  <h2 class="mt-16 font-mono text-4xl font-extrabold">
-    {{ i18n "shortcode.recent_articles" | emojify }}
-  </h2>
-  {{ range first .Site.Params.homepage.recentLimit (.Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) .Site.Params.homepage.recentLimit).Pages }}
-    {{ partial "article-link.html" . }}
-  {{ end }}
-{{ end }}

--- a/layouts/_partials/recent-posts.html
+++ b/layouts/_partials/recent-posts.html
@@ -16,7 +16,7 @@
     <a
       class="hover:text-primary-600 decoration-primary-600 mt-6 text-gray-500 hover:underline hover:underline-offset-2"
       href="{{ "posts" | relLangURL }}"
-      >{{ i18n "show-all" }} {{ i18n "posts" }} →</a
+      >{{ i18n "show-more" }} {{ i18n "posts" }} →</a
     >
   </div>
 </div>

--- a/layouts/_partials/recent-posts.html
+++ b/layouts/_partials/recent-posts.html
@@ -1,0 +1,22 @@
+<div class="mx-auto max-w-7xl bg-white pb-4 sm:pb-6">
+  <div class="mb-10 mb-8 px-4 sm:mb-10 sm:px-0">
+    <div class="mx-auto mb-8 max-w-2xl sm:mb-10 lg:mx-0">
+      <h2 class="mb-8 mt-16 text-4xl font-extrabold">{{ i18n "recent-posts" }}</h2>
+      <p class="mt-2 text-lg/8 text-gray-600">{{ i18n "posts-description" }}</p>
+    </div>
+
+    {{ $posts := .Site.GetPage "section" "posts" }}
+    {{ $past_posts := where $posts.Pages ".Date" "le" now }}
+
+    {{ range first 5 (sort $past_posts ".Date" "desc") }}
+      {{ partial "article-link.html" . }}
+    {{ end }}
+  </div>
+  <div class="mx-4 lg:mx-0">
+    <a
+      class="hover:text-primary-600 decoration-primary-600 mt-6 text-gray-500 hover:underline hover:underline-offset-2"
+      href="{{ "posts" | relLangURL }}"
+      >{{ i18n "show-all" }} {{ i18n "posts" }} →</a
+    >
+  </div>
+</div>

--- a/layouts/_partials/recent-resources.html
+++ b/layouts/_partials/recent-resources.html
@@ -4,17 +4,14 @@
       <h2 class="mb-8 mt-16 text-4xl font-extrabold">{{ i18n "featured" }}</h2>
       <p class="mt-2 text-lg/8 text-gray-600">{{ i18n "resources-description" }}</p>
     </div>
-    {{ if .Site.Params.homepage.showRecent | default false }}
-      <!-- <h2 class="mt-16 mb-8 text-4xl font-extrabold">{{ i18n "featured" | emojify }}</h2> -->
-      <div
-        class="mx-auto grid max-w-2xl grid-cols-1 gap-x-4 gap-y-16 lg:mx-0 lg:max-w-none lg:grid-cols-3"
-      >
-        {{ $recentResource := first 3 (where .Site.RegularPages "Section" "resources") }}
-        {{ range $recentResource }}
-          {{ partial "resource-link.html" . }}
-        {{ end }}
-      </div>
-    {{ end }}
+    <div
+      class="mx-auto grid max-w-2xl grid-cols-1 gap-x-4 gap-y-16 lg:mx-0 lg:max-w-none lg:grid-cols-3"
+    >
+      {{ $recentResource := first 3 (where .Site.RegularPages "Section" "resources") }}
+      {{ range $recentResource }}
+        {{ partial "resource-link.html" . }}
+      {{ end }}
+    </div>
   </div>
   <div class="mx-4 lg:mx-0">
     <a

--- a/layouts/_partials/resource-link.html
+++ b/layouts/_partials/resource-link.html
@@ -13,7 +13,7 @@
         aria-label="{{ $.Title | emojify }}"
       >
         <img
-          alt="{{ $.Params.featureAlt | default $.Params.thumbnailAlt | default "{{ $.Title | emojify }}" }}"
+          alt="{{ $.Params.featureAlt | default $.Params.thumbnailAlt | default $.Title | emojify }}"
           class="w-full h-auto aspect-square object-cover rounded-md"
           src="{{ .RelPermalink }}"
 

--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -1,0 +1,53 @@
+{{ define "main" }}
+  {{ $toc := and (.Params.showTableOfContents | default (.Site.Params.list.showTableOfContents | default false)) (in .TableOfContents "<ul") }}
+  <header>
+    {{ if .Params.showBreadcrumbs | default (.Site.Params.list.showBreadcrumbs | default false) }}
+      {{ partial "breadcrumbs.html" . }}
+    {{ end }}
+    <h1 class="mt-0 text-4xl font-extrabold text-neutral-900">{{ .Title }}</h1>
+  </header>
+  <section
+    class="{{ if $toc -}}
+      mt-12
+    {{- else -}}
+      mt-0
+    {{- end }} prose flex max-w-full flex-col lg:flex-row"
+  >
+    {{ if $toc }}
+      <div class="order-first px-0 lg:order-last lg:max-w-xs lg:ps-8">
+        <div class="toc ps-5 lg:sticky lg:top-10">
+          {{ partial "toc.html" . }}
+        </div>
+      </div>
+    {{ end }}
+    <div class="min-h-0 min-w-0 max-w-prose grow">
+      {{ .Content | emojify }}
+    </div>
+  </section>
+  {{ if .Data.Pages }}
+    <section>
+      {{ if $.Params.groupByYear | default ($.Site.Params.list.groupByYear | default true) }}
+        {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+          <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8">
+            {{ .Key }}
+          </h2>
+          <hr class="w-36 border-dotted border-neutral-400" />
+          {{ range .Pages }}
+            {{ partial "article-link.html" . }}
+          {{ end }}
+        {{ end }}
+      {{ else }}
+        {{ range (.Paginate .Pages).Pages }}
+          {{ partial "article-link.html" . }}
+        {{ end }}
+      {{ end }}
+    </section>
+    {{ partial "pagination.html" . }}
+  {{ else }}
+    <section class="prose mt-10">
+      <p class="border-t py-8">
+        <em>{{ i18n "list.no_articles" | emojify }}</em>
+      </p>
+    </section>
+  {{ end }}
+{{ end }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,0 +1,66 @@
+{{ define "main" }}
+  {{- $images := .Resources.ByType "image" }}
+  {{- $cover := $images.GetMatch (.Params.cover | default "*cover*") }}
+  {{- $feature := $images.GetMatch (.Params.feature | default "*feature*") | default $cover }}
+  <article>
+    <header class="max-w-prose">
+      {{ if .Params.showBreadcrumbs | default (.Site.Params.article.showBreadcrumbs | default false) }}
+        {{ partial "breadcrumbs.html" . }}
+      {{ end }}
+      <h1 class="mb-8 mt-0 text-4xl font-extrabold text-neutral-900">
+        {{ .Title | emojify }}
+      </h1>
+      {{ if or
+        (.Params.showDate | default (.Site.Params.article.showDate | default true))
+        (and (.Params.showDateUpdated | default (.Site.Params.article.showDateUpdated | default false)) (ne (partial "functions/date.html" .Date) (partial "functions/date.html" .Lastmod)))
+        (and (.Params.showWordCount | default (.Site.Params.article.showWordCount | default false)) (ne .WordCount 0))
+        (and (.Params.showReadingTime | default (.Site.Params.article.showReadingTime | default true)) (ne .ReadingTime 0))
+        (.Params.showEdit | default (.Site.Params.article.showEdit | default false))
+      }}
+        <div class="mb-10 text-base text-neutral-500 print:hidden">
+          {{ partial "article-meta.html" (dict "context" . "scope" "single") }}
+        </div>
+      {{ end }}
+      {{ with $feature }}
+        <div class="prose">
+          {{ $altText := $.Params.featureAlt | default $.Params.coverAlt | default "" }}
+          {{ $class := "mb-6 rounded-md" }}
+          {{ $webp := $.Page.Site.Params.enableImageWebp | default true }}
+          {{ partial "picture.html" (dict "img" . "alt" $altText "class" $class "lazy" false "webp" $webp) }}
+          {{ with $.Params.coverCaption }}
+            <figcaption class="-mt-3 mb-6 text-center">{{ . | markdownify }}</figcaption>
+          {{ end }}
+        </div>
+      {{ end }}
+    </header>
+    <section class="prose mt-0 flex max-w-full flex-col lg:flex-row">
+      {{ if and (.Params.showTableOfContents | default (.Site.Params.article.showTableOfContents | default false)) (in .TableOfContents "<ul") }}
+        <div class="order-first px-0 lg:order-last lg:max-w-xs lg:ps-8">
+          <div class="toc pe-5 lg:sticky lg:top-10 print:hidden">
+            {{ partial "toc.html" . }}
+          </div>
+        </div>
+      {{ end }}
+      <div class="min-h-0 min-w-0 max-w-prose grow">
+        {{ .Content | emojify }}
+      </div>
+    </section>
+    <footer class="max-w-prose pt-8 print:hidden">
+      {{ partial "author.html" . }}
+      {{ partial "sharing-links.html" . }}
+      {{ partial "article-pagination.html" . }}
+      {{ if .Params.showComments | default (.Site.Params.article.showComments | default false) }}
+        {{ if templates.Exists "comments.html" }}
+          <div class="pt-3">
+            <hr class="border-dotted border-neutral-300" />
+            <div class="pt-3">
+              {{ partial "comments.html" . }}
+            </div>
+          </div>
+        {{ else }}
+          {{ warnf "[CONGO] Comments are enabled for %s but no comments partial exists." .File.Path }}
+        {{ end }}
+      {{ end }}
+    </footer>
+  </article>
+{{ end }}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -212,10 +212,15 @@ collections:
         name: title
         widget: string
         i18n: true
-      - label: Description
-        name: description
+      - label: Summary
+        name: summary
         widget: string
         i18n: true
+      - label: Show Summary
+        name: showSummary
+        widget: boolean
+        i18n: duplicate
+        default: true
       - label: Author
         name: author
         widget: string


### PR DESCRIPTION
In this PR:

- **Create a news list on the home page, removing the menu item**
- **Use summary instead of description for posts** - see screenshot
- (smol adjustment) **Always show homepage resources (no need for a feature flag)**
- **Namespace posts layouts** - copy/paste from default
- **Fix alt text on recent resouces images** - was broken when no alt text was specified (e.g. on all)

Moot: News is less important than the other links and can just be in the flow instead?

Happy to keep the menu item too, but if we do, I'll push a separate commit that can change the breakpoint of the menu to wrap early

## Motive for this PR:

![Screenshot_20250511_150731](https://github.com/user-attachments/assets/6116921b-a42b-4390-af2d-ec8aee53e134)

On screen widths 640 < x < 920, the site looks a little squishy.


## How it looks full page without news in header

![Screenshot 2025-05-11 at 15-05-38 Tech­werkers­coalitie](https://github.com/user-attachments/assets/335f5a45-5f85-4db8-8da9-842b6df21d1e)
