### PR TITLE
Swap placement of news on homepage

### DIFF
--- a/content/posts/dag-van-de-arbeid-looptocht-1-mei-2025/index.en.md
+++ b/content/posts/dag-van-de-arbeid-looptocht-1-mei-2025/index.en.md
@@ -1,6 +1,6 @@
 ---
 title: Labour day walk - 1 May 2025
-summary: Tech workers represent in person at the Labour Day walk in Amsterdam
+summary: Tech workers represent in person at the Labour Day walk in Amsterdam.
 showSummary: true
 author: Ben
 date: 2025-05-08T12:00:00+02:00

--- a/content/posts/dag-van-de-arbeid-looptocht-1-mei-2025/index.nl.md
+++ b/content/posts/dag-van-de-arbeid-looptocht-1-mei-2025/index.nl.md
@@ -1,7 +1,6 @@
 ---
 title: Dag van de arbeid-parade - 1 Mei 2025
-summary: Techwerkers zijn persoonlijk aanwezig bij de Dag van de Arbeid-parade
-  in Amsterdam
+summary: Techwerkers zijn persoonlijk aanwezig bij de Dag van de Arbeid-parade in Amsterdam.
 showSummary: true
 author: Ben
 date: 2025-05-08T12:00:00+02:00

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -36,6 +36,8 @@
   translation: "Submit"
 - id: show-all
   translation: "Show all"
+- id: show-more
+  translation: "Show more"
 - id: show-resources
   translation: "Show all resources"
 - id: read-more

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -36,6 +36,8 @@
   translation: "Verstuur"
 - id: show-all
   translation: "Toon alle"
+- id: show-more
+  translation: "Toon meer"
 - id: show-resources
   translation: "Naar de kennisbank"
 - id: read-more
@@ -53,7 +55,7 @@
 - id: resources-description
   translation: "Handige info voor techwerkers."
 - id: recent-posts
-  translation: "Recent nieuws"
+  translation: "Laatste nieuws"
 - id: posts
   translation: "nieuws"
 - id: post-description

--- a/layouts/_partials/home/page.html
+++ b/layouts/_partials/home/page.html
@@ -26,11 +26,11 @@
 </section>
 
 <section class="not-prose">
-  {{ partial "events-upcoming.html" . }}
+  {{ partial "recent-posts.html" . }}
 </section>
 
 <section class="not-prose">
-  {{ partial "recent-posts.html" . }}
+  {{ partial "events-upcoming.html" . }}
 </section>
 
 <section class="not-prose">

--- a/layouts/_partials/recent-posts.html
+++ b/layouts/_partials/recent-posts.html
@@ -16,7 +16,7 @@
     <a
       class="hover:text-primary-600 decoration-primary-600 mt-6 text-gray-500 hover:underline hover:underline-offset-2"
       href="{{ "posts" | relLangURL }}"
-      >{{ i18n "show-all" }} {{ i18n "posts" }} →</a
+      >{{ i18n "show-more" }} {{ i18n "posts" }} →</a
     >
   </div>
 </div>


### PR DESCRIPTION
Some small suggestions for the [home page news PR](https://github.com/techworkersco/twc-site-nl/pull/98):

- Place the new section higher up on the home page, before the events list. 
  - Motivation: 'Recent news' sounds like something that's OK show first, and it provides some differentiation in the visual rhythm (news => image + txt, events => plain list, resources => image + txt).

_Preview of changed order_

![Screenshot 2025-05-13 at 18 47 38](https://github.com/user-attachments/assets/3301a290-466c-4789-90a3-36797edad87b)

- Adjust some wording to make it sound slightly more natural in Dutch, with corresponding changes in English.
- Add a period at end of news post summary to make it look tidier in the display. 