### PR TITLE
(Fix) Clarify no bosses or managers on join page

### DIFF
--- a/content/join/index.en.md
+++ b/content/join/index.en.md
@@ -4,3 +4,5 @@ description: "Stronger together! Join the Tech Workers Coalition today. Fill out
 ---
 
 ![Three people sit around a table in a café behind a laptop, laughing together, pointing at a mobile phone. Image by Ketut Subiyanto on Pexels.](join.jpg)
+
+**Note:** You can only join the Tech Workers Coalition if you're currently _**not**_ in a role where you have hiring, firing, promotion, or demotion power over other workers. This is to make it easier for tech workers to speak and act freely within the coalition, without fear of on-the-job reprisal. 

--- a/content/join/index.nl.md
+++ b/content/join/index.nl.md
@@ -1,6 +1,8 @@
 ---
-title: "Doe mee met de Techwerkerscoalitie"
+title: "Doe mee met Techwerkers"
 description: "Samen bereik je meer! Sluit je vandaag nog aan bij de Techwerkerscoalitie. Vul het aanmeldformulier in en een techwerker neemt contact met je op."
 ---
 
 ![Drie mensen zitten rond een tafel in een café achter een laptop, samen lachend, en wijzen naar een mobiele telefoon. Afbeelding door Ketut Subiyanto op Pexels.](join.jpg)
+
+**Let op:** Je kunt je alleen aansluiten bij Techwerkers als je momenteel _**niet**_ een functie hebt waarin je invloed hebt over het aannemen, ontslaan, promoveren, of demoveren van andere arbeiders. Dit om het voor techwerkers makkelijker te maken om binnen de coalitie vrij te kunnen spreken, zonder angst voor represailles op de werkvloer.

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -11,7 +11,7 @@
 - id: join
   translation: "Join the Tech Workers Coalition"
 - id: join-description
-  translation: "Fill out the following information so we can get to know you better!"
+  translation: "Fill out your details to join."
 - id: join-form
   translation: "Your details"
 - id: name

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -11,7 +11,7 @@
 - id: join
   translation: "Doe mee met de Techwerkerscoalitie"
 - id: join-description
-  translation: "Vul de volgende gegevens in, zodat we je alvast iets beter kunnen leren kennen!"
+  translation: "Vul hier je gegevens in om je aan te melden."
 - id: join-form
   translation: "Je gegevens"
 - id: name


### PR DESCRIPTION
This change adds a note on the Join page to clarify that you can't join if you've got hiring/firing/promotion/demotion power over other workers --- i.e. no bosses or people managers. 

Previously, we had a similar note on this page, but it perished in the Grand Join Page Cleanup a couple of months ago. This change adds such a note back in.

In addition:
- It removes 'we' from the join description, and simplifies this description a bit.
- On the Dutch page, it changes the heading with a CTA to join 'Techwerkers', rather than 'Techwerkerscoalitie', which is just a bit of a mouthful 😄 