### PR TITLE
add NL prefix to events listing

### DIFF
--- a/layouts/_default/events.yaml
+++ b/layouts/_default/events.yaml
@@ -2,7 +2,7 @@
 {{- range sort $events ".Date" "asc" -}}
 {{- $images := .Resources.ByType "image" -}}
 {{- $feature := $images.GetMatch .Params.feature }}
-- title: {{ .Params.title | jsonify }}
+- title: NL {{ .Params.title | jsonify }}
   date: {{ .Date.Format "2006-01-02 15:04:05 -07:00" }}
   locations: [{{ .Params.location | jsonify }}]
   tags: {{ .Params.tags | jsonify }}

--- a/layouts/_default/events.yaml
+++ b/layouts/_default/events.yaml
@@ -2,7 +2,8 @@
 {{- range sort $events ".Date" "asc" -}}
 {{- $images := .Resources.ByType "image" -}}
 {{- $feature := $images.GetMatch .Params.feature }}
-- title: NL {{ .Params.title | jsonify }}
+{{- $fulltitle := (print "NL: " .Params.title) -}}
+- title:{{ $fulltitle | jsonify }}
   date: {{ .Date.Format "2006-01-02 15:04:05 -07:00" }}
   locations: [{{ .Params.location | jsonify }}]
   tags: {{ .Params.tags | jsonify }}


### PR DESCRIPTION
The goal of this pr is to get "NL" added as prefix to the events in the /en/index/events.yaml file so that they import into the main twc calendar with location clear.