### PR TITLE
Revert "add NL prefix to events listing"

### DIFF
--- a/layouts/_default/events.yaml
+++ b/layouts/_default/events.yaml
@@ -2,8 +2,7 @@
 {{- range sort $events ".Date" "asc" -}}
 {{- $images := .Resources.ByType "image" -}}
 {{- $feature := $images.GetMatch .Params.feature }}
-{{- $fulltitle := (print "NL: " .Params.title) -}}
-- title:{{ $fulltitle | jsonify }}
+- title: {{ .Params.title | jsonify }}
   date: {{ .Date.Format "2006-01-02 15:04:05 -07:00" }}
   locations: [{{ .Params.location | jsonify }}]
   tags: {{ .Params.tags | jsonify }}


### PR DESCRIPTION
This breaks yaml syntax and moves url/title to same line
`url: https://deploy-preview-108--twc-site-nl.netlify.app/en/events/2025-02-03/- title:"NL: Organizing for Power | Session #1"` 
Reverts techworkersco/twc-site-nl#108