### PR TITLE
Prefix Netherlands for global event consumer

### DIFF
--- a/layouts/_default/events.yaml
+++ b/layouts/_default/events.yaml
@@ -2,7 +2,7 @@
 {{- range sort $events ".Date" "asc" -}}
 {{- $images := .Resources.ByType "image" -}}
 {{- $feature := $images.GetMatch .Params.feature }}
-- title: {{ .Params.title | jsonify }}
+- title: {{ printf "Netherlands: %s" .Params.title | jsonify }}
   date: {{ .Date.Format "2006-01-02 15:04:05 -07:00" }}
   locations: [{{ .Params.location | jsonify }}]
   tags: {{ .Params.tags | jsonify }}


### PR DESCRIPTION
This modifies all titles of events generated in the YAML file at https://deploy-preview-111--twc-site-nl.netlify.app/en/events/index.yaml (or http://techwekers.nl/en/events/index.yaml on production) to have a `Netherlands:` string prefix which adds more context for events like "Organizing meetup" on the global events page of TWC. 

Here is the older pull request that loads Dutch events into global website https://github.com/techworkersco/twc-site/pull/432

 

<img width="486" alt="Screenshot 2025-05-23 at 19 57 59" src="https://github.com/user-attachments/assets/c9b63f96-9e04-4e82-9fc2-76120d89cdb7" />
