### PR TITLE
Center content on pages

### DIFF
--- a/layouts/campaigns/list.html
+++ b/layouts/campaigns/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   {{ $toc := and (.Params.showTableOfContents | default (.Site.Params.list.showTableOfContents | default false)) (in .TableOfContents "<ul") }}
-  <header>
+  <header class="mx-auto max-w-5xl">
     {{ if .Params.showBreadcrumbs | default (.Site.Params.list.showBreadcrumbs | default false) }}
       {{ partial "breadcrumbs.html" . }}
     {{ end }}
@@ -11,7 +11,7 @@
       mt-12
     {{- else -}}
       mt-0
-    {{- end }} prose flex max-w-full flex-col lg:flex-row"
+    {{- end }} prose mx-auto flex max-w-5xl flex-col lg:flex-row"
   >
     {{ if $toc }}
       <div class="order-first px-0 lg:order-last lg:max-w-xs lg:ps-8">
@@ -25,7 +25,7 @@
     </div>
   </section>
   {{ if .Data.Pages }}
-    <section>
+    <section class="mx-auto max-w-5xl">
       {{ if $.Params.groupByYear | default ($.Site.Params.list.groupByYear | default true) }}
         {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
           <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8">

--- a/layouts/campaigns/single.html
+++ b/layouts/campaigns/single.html
@@ -3,7 +3,7 @@
   {{- $campaign := .Params.campaign }}
   {{- $cover := $images.GetMatch (.Params.cover | default "*cover*") }}
   {{- $feature := $images.GetMatch (.Params.feature | default "*feature*") | default $cover }}
-  <article>
+  <article class="mx-auto max-w-5xl">
     <header class="max-w-prose">
       {{ if .Params.showBreadcrumbs | default (.Site.Params.article.showBreadcrumbs | default false) }}
         {{ partial "breadcrumbs.html" . }}

--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   {{ $toc := and (.Params.showTableOfContents | default (.Site.Params.list.showTableOfContents | default false)) (in .TableOfContents "<ul") }}
-  <header>
+  <header class="mx-auto max-w-5xl">
     {{ if .Params.showBreadcrumbs | default (.Site.Params.list.showBreadcrumbs | default false) }}
       {{ partial "breadcrumbs.html" . }}
     {{ end }}
@@ -11,7 +11,7 @@
       mt-12
     {{- else -}}
       mt-0
-    {{- end }} prose flex max-w-full flex-col lg:flex-row"
+    {{- end }} prose mx-auto flex max-w-5xl flex-col lg:flex-row"
   >
     {{ if $toc }}
       <div class="order-first px-0 lg:order-last lg:max-w-xs lg:ps-8">
@@ -25,7 +25,7 @@
     </div>
   </section>
   {{ if .Data.Pages }}
-    <section>
+    <section class="mx-auto max-w-5xl">
       {{ if $.Params.groupByYear | default ($.Site.Params.list.groupByYear | default true) }}
         {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
           <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8">

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -2,7 +2,7 @@
   {{- $images := .Resources.ByType "image" }}
   {{- $cover := $images.GetMatch (.Params.cover | default "*cover*") }}
   {{- $feature := $images.GetMatch (.Params.feature | default "*feature*") | default $cover }}
-  <article>
+  <article class="mx-auto max-w-5xl">
     <header class="max-w-prose">
       {{ if .Params.showBreadcrumbs | default (.Site.Params.article.showBreadcrumbs | default false) }}
         {{ partial "breadcrumbs.html" . }}

--- a/layouts/resources/single.html
+++ b/layouts/resources/single.html
@@ -2,7 +2,7 @@
   {{- $images := .Resources.ByType "image" }}
   {{- $cover := $images.GetMatch (.Params.cover | default "*cover*") }}
   {{- $feature := $images.GetMatch (.Params.feature | default "*feature*") | default $cover }}
-  <article>
+  <article class="mx-auto max-w-5xl">
     <header class="max-w-prose">
       {{ if .Params.showBreadcrumbs | default (.Site.Params.article.showBreadcrumbs | default false) }}
         {{ partial "breadcrumbs.html" . }}


### PR DESCRIPTION
Just testing out what it would look like if all the pages were centered.

On full page/large screens, the content sits more in the middle. I personally never use full page screens, I  always have tiled windows left etc. However for those that do full page, this is what it looks like right now on large screens:

![Screenshot_20250625_210805](https://github.com/user-attachments/assets/23ef3dbf-43fb-4fc2-9ed5-292847b7abf5)

I'm not really sure what is better looking, but just throwing it out there.

This is what it looks like with this PR:

![Screenshot_20250625_211057](https://github.com/user-attachments/assets/c6bba0b6-aea8-4ad6-95c9-5a2241a3fbbc)
