### PR TITLE
Add postponement note to AI reading group session

### DIFF
--- a/content/events/2025-07-08/index.en.md
+++ b/content/events/2025-07-08/index.en.md
@@ -1,10 +1,12 @@
 ---
-title: "AI Sceptics Reading Group"
+title: "Postponed: AI Sceptics Reading Group"
 date: 2025-07-08T18:00:00+02:00
 location: "Online"
 organisation: ""
 tags: ["reading-group"]
 ---
+
+**Postponed! A new date and time will be confirmed soon**
 
 A reading and discussion group for tech workers who are sceptical of, or questioning, the role of AI in relation to tech labour.
 

--- a/content/events/2025-07-08/index.nl.md
+++ b/content/events/2025-07-08/index.nl.md
@@ -1,10 +1,12 @@
 ---
-title: "AI Sceptici Leesgroep"
+title: "Uitgesteld: AI Sceptici Leesgroep"
 date: 2025-07-08T18:00:00+02:00
 location: "Online"
 organisation: ""
 tags: ["reading-group"]
 ---
+
+**Uitgesteld! Een nieuwe datum en tijd worden binnenkort bevestigd**
 
 *Voertaal: Engels*
 


### PR DESCRIPTION
This change postpones the AI reading group (originally scheduled for 8 July) to a future date to be confirmed. Merging directly because it's a purely textual change.