### PR TITLE
Add events: organizing training + pride march

### DIFF
--- a/content/events/2025-07-25/index.en.md
+++ b/content/events/2025-07-25/index.en.md
@@ -1,0 +1,17 @@
+---
+title: "Workshop: How to hold an organizing conversation"
+date: 2025-07-25T02:30:00+02:00
+location: "Online"
+organisation: ""
+tags: ["training"]
+---
+
+⚠️ *Caution: Due to timezone scheduling this workshop takes place in the middle of the night* ⚠️ 
+
+Join Tech Workers Coalition in the first organizing skills workshop of the summer! You'll be learning about and ✨ practicing ✨ *structured organizing conversations*.
+
+Organizing conversations are a core skill for every tech worker, whether you want to form a union at your shop, or building community power against an incoming data center. 
+
+Come attend this two-hour workshop where you'll learn the parts of an organizing conversation, practice these conversations in small groups, and get to know other tech workers who are also learning alongside.
+
+[Register now](https://us02web.zoom.us/meeting/register/9yMuxo_3SluATUUTq1PErA#/registration)

--- a/content/events/2025-07-25/index.nl.md
+++ b/content/events/2025-07-25/index.nl.md
@@ -1,0 +1,19 @@
+---
+title: "Training: Hoe houd je een organisatiegesprek"
+date: 2025-07-25T02:30:00+02:00
+location: "Online"
+organisation: ""
+tags: ["training"]
+---
+
+*Voertaal: Engels*
+
+⚠️ *Let op: Vanwege de tijdzoneplanning vindt deze workshop midden in de nacht plaats* ⚠️
+
+Doe mee met de eerste Techwerkersworkshop over organisatievaardigheden van deze zomer! Je leert over en ✨ oefent ✨ *gestructureerde organisatiegesprekken voeren*.
+
+Het voeren van organisatiegesprekken is een essentiële vaardigheid voor elke techwerker, of je nu een vakbond wilt oprichten of de kracht van een gemeenschap wilt versterken tegen een aankomend datacenter.
+
+Neem deel aan deze twee uur durende workshop waarin je leert wat de onderdelen van een organisatiegesprek zijn, in kleine groepjes oefent zulke gesprekken te voeren, én andere techwerkers leert kennen die ook meedoen.
+
+[Meld je nu aan](https://us02web.zoom.us/meeting/register/9yMuxo_3SluATUUTq1PErA#/registration)

--- a/content/events/2025-07-26/index.en.md
+++ b/content/events/2025-07-26/index.en.md
@@ -1,0 +1,19 @@
+---
+title: "Tech workers @ Pride March"
+date: 2025-07-26T11:00:00+02:00
+location: "Amstelveld to Vondelpark, Amsterdam"
+organisation: ""
+tags: ["event"]
+---
+
+Tech workers are joining [Pride March in Amsterdam](https://pride.amsterdam/en/event/pride-march/) on 26 July. Come and say hi!!
+
+Official info:
+
+> Route: Amstelveld, Utrechtsestraat, Reguliersdwarsstraat, Vijzelgracht, Weteringschans, Leidseplein, Vondelpark.
+>
+> Gathering: 11am
+>
+> Start Pride March: 12:00pm
+
+Look out for Tech Worker flags :)

--- a/content/events/2025-07-26/index.nl.md
+++ b/content/events/2025-07-26/index.nl.md
@@ -1,0 +1,19 @@
+---
+title: "Techwerkers @ Pride March"
+date: 2025-07-26T11:00:00+02:00
+location: "Amstelveld naar Vondelpark, Amsterdam"
+organisation: ""
+tags: ["evenement"]
+---
+
+Techwerkers nemen op 26 juli deel aan [*Pride March* (Trotsmars) in Amsterdam](https://pride.amsterdam/event/pride-march/). Kom kennismaken!!
+
+Officiële informatie:
+
+> Route: Amstelveld, Utrechtsestraat, Reguliersdwarsstraat, Vijzelgracht, Weteringschans, Leidseplein, Vondelpark.
+>
+> Verzamelen: 11.00 uur
+>
+> Start van de mars: 12.00 uur
+
+Kijk uit naar Techwerkersvlaggen :)


### PR DESCRIPTION
This change adds two upcoming events to the events overview:
- 25 July: Organizing conversation training (by TWC global)
- 26 July: Tech workers @ Pride Amsterdam