### PR TITLE
Update email signup to use listmonk

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -11,8 +11,8 @@
 # ordered by weight from lowest to highest.
 
 [[main]]
-  name = "Organize your workplace"
-  pageRef = "resources/organize"
+  name = "Resources"
+  pageRef = "resources"
   weight = 10
 
 [[main]]
@@ -21,14 +21,14 @@
   weight = 20
 
 [[main]]
-  name = "Resources"
-  pageRef = "resources"
+  name = "About"
+  pageRef = "about"
   weight = 30
 
 [[main]]
-  name = "About"
-  pageRef = "about"
-  weight = 35
+  name = "Newsletter"
+  pageRef = "newsletter"
+  weight = 40
 
 [[main]]
   name = "Join"

--- a/config/_default/menus.nl.toml
+++ b/config/_default/menus.nl.toml
@@ -11,24 +11,24 @@
 # ordered by weight from lowest to highest.
 
 [[main]]
-  name = "Organiseer je werkplek"
-  pageRef = "resources/organize"
+  name = "Kennisbank"
+  pageRef = "resources"
   weight = 10
 
 [[main]]
   name = "Agenda"
   url = "https://events.techwerkers.nl/"
   weight = 20
-
-[[main]]
-  name = "Kennisbank"
-  pageRef = "resources"
-  weight = 30
-
+  
 [[main]]
   name = "Over"
   pageRef = "about"
-  weight = 35
+  weight = 30
+
+[[main]]
+  name = "Nieuwsbrief"
+  pageRef = "newsletter"
+  weight = 40
 
 [[main]]
   name = "Doe mee"

--- a/content/newsletter/index.en.md
+++ b/content/newsletter/index.en.md
@@ -1,6 +1,6 @@
 ---
 title: Newsletter
-description: "Get the latest from Techwerkers on tech & worker power in the Netherlands. Insights, guides, events for nerds, all directly in your inbox."
+description: "Get the latest on tech + worker power in the Netherlands. Articles, training, and nerdy events all directly in your inbox."
 date: 2026-01-15T00:00:00.000Z
 lastmod: 2026-01-16T00:00:00.000Z
 showDate: false
@@ -8,7 +8,6 @@ showDateUpdated: false
 sharingLinks: false
 ---
 
-Get the latest from Techwerkers on tech & worker power in the Netherlands. Insights, guides, events for nerds, all directly in your inbox.
+Get the latest on tech + worker power in the Netherlands. Articles, training, and nerdy events all directly in your inbox.
 
-<iframe data-tally-src="https://tally.so/embed/lbOVPN?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1" loading="lazy" width="100%" height="462" frameborder="0" marginheight="0" marginwidth="0" title="null"></iframe>
-<script>var d=document,w="https://tally.so/widgets/embed.js",v=function(){"undefined"!=typeof Tally?Tally.loadEmbeds():d.querySelectorAll("iframe[data-tally-src]:not([src])").forEach((function(e){e.src=e.dataset.tallySrc}))};if("undefined"!=typeof Tally)v();else if(d.querySelector('script[src="'+w+'"]')==null){var s=d.createElement("script");s.src=w,s.onload=v,s.onerror=v,d.body.appendChild(s);}</script>
+{{< newsletter-en >}}

--- a/content/newsletter/index.nl.md
+++ b/content/newsletter/index.nl.md
@@ -1,6 +1,6 @@
 ---
 title: Nieuwsbrief
-description: "Ontvang het laatste nieuws van Techwerkers over tech & arbeid in Nederland. Inzichten, artikelen, en bijeenkomsten voor nerds, allemaal direct in je inbox."
+description: "Ontvang het laatste van over tech + arbeid in Nederland. Artikelen, training, nerdy activiteiten, maandelijks direct in je inbox."
 date: 2026-01-15T00:00:00.000Z
 lastmod: 2026-01-16T00:00:00.000Z
 showDate: false
@@ -8,7 +8,6 @@ showDateUpdated: false
 sharingLinks: false
 ---
 
-Ontvang het laatste nieuws van Techwerkers over tech & arbeid in Nederland. Inzichten, artikelen, en bijeenkomsten voor nerds, allemaal direct in je inbox.
+Ontvang het laatste van over tech + arbeid in Nederland. Artikelen, training, nerdy activiteiten, maandelijks direct in je inbox.
 
-<iframe data-tally-src="https://tally.so/embed/lbOVPN?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1" loading="lazy" width="100%" height="462" frameborder="0" marginheight="0" marginwidth="0" title="null"></iframe>
-<script>var d=document,w="https://tally.so/widgets/embed.js",v=function(){"undefined"!=typeof Tally?Tally.loadEmbeds():d.querySelectorAll("iframe[data-tally-src]:not([src])").forEach((function(e){e.src=e.dataset.tallySrc}))};if("undefined"!=typeof Tally)v();else if(d.querySelector('script[src="'+w+'"]')==null){var s=d.createElement("script");s.src=w,s.onload=v,s.onerror=v,d.body.appendChild(s);}</script>
+{{< newsletter-nl >}}

--- a/layouts/_shortcodes/newsletter-en.html
+++ b/layouts/_shortcodes/newsletter-en.html
@@ -1,0 +1,18 @@
+<form method="post" action="https://listmonk.techwerkers.nl/subscription/form" class="listmonk-form">
+  <div>
+    <input type="hidden" name="nonce" />
+    <label for="name" class="text-gray-900 mb-2 block font-bold">Email </label>
+    <p><input type="email" name="email" required placeholder="Your email" class="border-gray-300 bg-gray-50 text-gray-900 focus:border-blue-500 focus:ring-blue-500 block w-full rounded-lg border p-2.5" /></p>
+
+    <!-- English list -->
+    <p>
+      <input id="bf05e" type="hidden" name="l" checked value="bf05e137-552e-4853-8089-e9eaf04e0285" />
+    </p>
+
+    <button class="rounded-md bg-primary-600 px-4 py-2 text-neutral no-underline hover:rounded-md hover:bg-primary-500">
+      <input type="submit" value="Subscribe →" />
+    </button>
+  </div>
+</form>
+
+

--- a/layouts/_shortcodes/newsletter-en.html
+++ b/layouts/_shortcodes/newsletter-en.html
@@ -1,18 +1,36 @@
-<form method="post" action="https://listmonk.techwerkers.nl/subscription/form" class="listmonk-form">
+<form
+  method="post"
+  action="https://listmonk.techwerkers.nl/subscription/form"
+  class="listmonk-form"
+>
   <div>
     <input type="hidden" name="nonce" />
     <label for="name" class="text-gray-900 mb-2 block font-bold">Email </label>
-    <p><input type="email" name="email" required placeholder="Your email" class="border-gray-300 bg-gray-50 text-gray-900 focus:border-blue-500 focus:ring-blue-500 block w-full rounded-lg border p-2.5" /></p>
+    <p>
+      <input
+        type="email"
+        name="email"
+        required
+        placeholder="Your email"
+        class="border-gray-300 bg-gray-50 text-gray-900 focus:border-blue-500 focus:ring-blue-500 block w-full rounded-lg border p-2.5"
+      />
+    </p>
 
     <!-- English list -->
     <p>
-      <input id="bf05e" type="hidden" name="l" checked value="bf05e137-552e-4853-8089-e9eaf04e0285" />
+      <input
+        id="bf05e"
+        type="hidden"
+        name="l"
+        checked
+        value="bf05e137-552e-4853-8089-e9eaf04e0285"
+      />
     </p>
 
-    <button class="rounded-md bg-primary-600 px-4 py-2 text-neutral no-underline hover:rounded-md hover:bg-primary-500">
+    <button
+      class="rounded-md bg-primary-600 px-4 py-2 text-neutral no-underline hover:rounded-md hover:bg-primary-500"
+    >
       <input type="submit" value="Subscribe →" />
     </button>
   </div>
 </form>
-
-

--- a/layouts/_shortcodes/newsletter-nl.html
+++ b/layouts/_shortcodes/newsletter-nl.html
@@ -1,0 +1,16 @@
+<form method="post" action="https://listmonk.techwerkers.nl/subscription/form" class="listmonk-form">
+  <div>
+    <input type="hidden" name="nonce" />
+    <label for="name" class="text-gray-900 mb-2 block font-bold">Email </label>
+    <p><input type="email" name="email" required placeholder="Je email" class="border-gray-300 bg-gray-50 text-gray-900 focus:border-blue-500 focus:ring-blue-500 block w-full rounded-lg border p-2.5" /></p>
+
+    <!-- Dutch list -->
+    <p>
+      <input id="0ecf5" type="hidden" name="l" checked value="0ecf5189-19be-44a1-9456-b490ae94084b" />
+    </p>
+
+    <button class="rounded-md bg-primary-600 px-4 py-2 text-neutral no-underline hover:rounded-md hover:bg-primary-500">
+      <input type="submit" value="Inschrijven →" />
+    </button>
+  </div>
+</form>

--- a/layouts/_shortcodes/newsletter-nl.html
+++ b/layouts/_shortcodes/newsletter-nl.html
@@ -1,15 +1,35 @@
-<form method="post" action="https://listmonk.techwerkers.nl/subscription/form" class="listmonk-form">
+<form
+  method="post"
+  action="https://listmonk.techwerkers.nl/subscription/form"
+  class="listmonk-form"
+>
   <div>
     <input type="hidden" name="nonce" />
     <label for="name" class="text-gray-900 mb-2 block font-bold">Email </label>
-    <p><input type="email" name="email" required placeholder="Je email" class="border-gray-300 bg-gray-50 text-gray-900 focus:border-blue-500 focus:ring-blue-500 block w-full rounded-lg border p-2.5" /></p>
+    <p>
+      <input
+        type="email"
+        name="email"
+        required
+        placeholder="Je email"
+        class="border-gray-300 bg-gray-50 text-gray-900 focus:border-blue-500 focus:ring-blue-500 block w-full rounded-lg border p-2.5"
+      />
+    </p>
 
     <!-- Dutch list -->
     <p>
-      <input id="0ecf5" type="hidden" name="l" checked value="0ecf5189-19be-44a1-9456-b490ae94084b" />
+      <input
+        id="0ecf5"
+        type="hidden"
+        name="l"
+        checked
+        value="0ecf5189-19be-44a1-9456-b490ae94084b"
+      />
     </p>
 
-    <button class="rounded-md bg-primary-600 px-4 py-2 text-neutral no-underline hover:rounded-md hover:bg-primary-500">
+    <button
+      class="rounded-md bg-primary-600 px-4 py-2 text-neutral no-underline hover:rounded-md hover:bg-primary-500"
+    >
       <input type="submit" value="Inschrijven →" />
     </button>
   </div>


### PR DESCRIPTION
This change updates the newsletter signup form to use Listmonk, instead of a disconnected Tally form. It uses a separate form for the EN and NL versions of the page, so that as least for new signups, we can send the newsletter in people's preferred language. (This corresponds to new lists created in Listmonk too. The old, multilingual list still exists.)

It also updates the menu:
- Remove the 'Organize your workplace' resource direct link; it's still discoverable under 'Resources'. (This resources is relevant but could use some review & update I think, so removing it pragmatically now so as not to make the nav menu v clogged.)
- Add 'Newsletter' nagivation link.

## Comparison

### Before

<img width="1450" height="573" alt="image" src="https://github.com/user-attachments/assets/c57eb7db-32ca-4251-9535-79ca8714239b" />

### After

<img width="1453" height="560" alt="image" src="https://github.com/user-attachments/assets/e227254b-7dea-4597-bf87-f700a628bb7a" />

## Future improvements

The only thing that's not completely tailored now is the confirmation page, which is a listmonk default page native rather than a page within Techwerkers. But I don't think it's that big of a deal? If we'd like to customize that too then I think it's fine to pick that up in a next iteration :slightly_smiling_face: 

## Testing

Manually tested both the English and Dutch form and the signups get registered in listmonk correctly.